### PR TITLE
feat: add C2PA context and configuration API (GP-291)

### DIFF
--- a/Library/Library.xcodeproj/project.pbxproj
+++ b/Library/Library.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		A0C2A0062E96B00100F2F938 /* SignerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0052E96B00100F2F938 /* SignerInfo.swift */; };
 		A0C2A0082E96B00100F2F938 /* C2PASettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0072E96B00100F2F938 /* C2PASettings.swift */; };
 		A0C2A00A2E96B00100F2F938 /* SettingsDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */; };
+		A0CTX0012E9700000000001 /* C2PAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CTX0022E9700000000001 /* C2PAContext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		A0C2A0052E96B00100F2F938 /* SignerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerInfo.swift; sourceTree = "<group>"; };
 		A0C2A0072E96B00100F2F938 /* C2PASettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C2PASettings.swift; sourceTree = "<group>"; };
 		A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDefinition.swift; sourceTree = "<group>"; };
+		A0CTX0022E9700000000001 /* C2PAContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C2PAContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -146,6 +148,7 @@
 				A0C2A0032E96B00100F2F938 /* C2PAJson.swift */,
 				A0C2A0072E96B00100F2F938 /* C2PASettings.swift */,
 				A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */,
+				A0CTX0022E9700000000001 /* C2PAContext.swift */,
 				8A1234571234567890ABCDEF /* CertificateManager.swift */,
 				95A782342E6F06E4001E9748 /* Helpers.swift */,
 				95A782352E6F06E4001E9748 /* KeychainSigner.swift */,
@@ -349,6 +352,7 @@
 				A0C2A0042E96B00100F2F938 /* C2PAJson.swift in Sources */,
 				A0C2A0082E96B00100F2F938 /* C2PASettings.swift in Sources */,
 				A0C2A00A2E96B00100F2F938 /* SettingsDefinition.swift in Sources */,
+				A0CTX0012E9700000000001 /* C2PAContext.swift in Sources */,
 				95A7823E2E6F06E4001E9748 /* KeychainSigner.swift in Sources */,
 				95A7823F2E6F06E4001E9748 /* Signer.swift in Sources */,
 				95A782402E6F06E4001E9748 /* Reader.swift in Sources */,

--- a/Library/Library.xcodeproj/project.pbxproj
+++ b/Library/Library.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		A0C2A0062E96B00100F2F938 /* SignerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0052E96B00100F2F938 /* SignerInfo.swift */; };
 		A0C2A0082E96B00100F2F938 /* C2PASettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0072E96B00100F2F938 /* C2PASettings.swift */; };
 		A0C2A00A2E96B00100F2F938 /* SettingsDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */; };
-		A0CTX0012E9700000000001 /* C2PAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CTX0022E9700000000001 /* C2PAContext.swift */; };
+		C20AC07E97000000000B0001 /* C2PAContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20AC07E97000000000B0002 /* C2PAContext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,7 +79,7 @@
 		A0C2A0052E96B00100F2F938 /* SignerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignerInfo.swift; sourceTree = "<group>"; };
 		A0C2A0072E96B00100F2F938 /* C2PASettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C2PASettings.swift; sourceTree = "<group>"; };
 		A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDefinition.swift; sourceTree = "<group>"; };
-		A0CTX0022E9700000000001 /* C2PAContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C2PAContext.swift; sourceTree = "<group>"; };
+		C20AC07E97000000000B0002 /* C2PAContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C2PAContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -148,7 +148,7 @@
 				A0C2A0032E96B00100F2F938 /* C2PAJson.swift */,
 				A0C2A0072E96B00100F2F938 /* C2PASettings.swift */,
 				A0C2A0092E96B00100F2F938 /* SettingsDefinition.swift */,
-				A0CTX0022E9700000000001 /* C2PAContext.swift */,
+				C20AC07E97000000000B0002 /* C2PAContext.swift */,
 				8A1234571234567890ABCDEF /* CertificateManager.swift */,
 				95A782342E6F06E4001E9748 /* Helpers.swift */,
 				95A782352E6F06E4001E9748 /* KeychainSigner.swift */,
@@ -352,7 +352,7 @@
 				A0C2A0042E96B00100F2F938 /* C2PAJson.swift in Sources */,
 				A0C2A0082E96B00100F2F938 /* C2PASettings.swift in Sources */,
 				A0C2A00A2E96B00100F2F938 /* SettingsDefinition.swift in Sources */,
-				A0CTX0012E9700000000001 /* C2PAContext.swift in Sources */,
+				C20AC07E97000000000B0001 /* C2PAContext.swift in Sources */,
 				95A7823E2E6F06E4001E9748 /* KeychainSigner.swift in Sources */,
 				95A7823F2E6F06E4001E9748 /* Signer.swift in Sources */,
 				95A782402E6F06E4001E9748 /* Reader.swift in Sources */,

--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -27,6 +27,8 @@ import Foundation
 /// - ``init(manifest:)``
 /// - ``init(manifestJSON:)``
 /// - ``init(archiveStream:)``
+/// - ``init(context:manifest:)``
+/// - ``init(context:manifestJSON:)``
 ///
 /// ### Configuring the Manifest
 /// - ``setIntent(_:)``
@@ -69,6 +71,11 @@ public final class Builder {
     /// Internal initializer that skips validation.
     private init(validatedJSON: String) throws {
         ptr = try guardNotNull(c2pa_builder_from_json(validatedJSON))
+    }
+
+    /// Internal initializer that adopts an already-configured native builder.
+    private init(adopting ptr: UnsafeMutablePointer<C2paBuilder>) {
+        self.ptr = ptr
     }
 
     /// Validates a ``ManifestValidationResult``, logging warnings and throwing on errors.
@@ -114,6 +121,43 @@ public final class Builder {
     /// - Throws: ``C2PAError`` if the archive is invalid or cannot be read.
     public init(archiveStream: Stream) throws {
         ptr = try guardNotNull(c2pa_builder_from_archive(archiveStream.rawPtr))
+    }
+
+    /// Creates a new builder from a ``C2PAContext`` and a manifest JSON definition.
+    ///
+    /// The builder inherits the context's configuration (settings), so values
+    /// such as created-assertion labels and trust configuration flow into the
+    /// signed manifest.
+    ///
+    /// - Parameters:
+    ///   - context: The ``C2PAContext`` providing shared configuration.
+    ///   - manifestJSON: A JSON string defining the C2PA manifest structure.
+    ///
+    /// - Throws: ``C2PAError`` if the builder cannot be created or the JSON is invalid.
+    ///
+    /// - SeeAlso: ``C2PAContext``
+    public convenience init(context: C2PAContext, manifestJSON: String) throws {
+        let base = try guardNotNull(c2pa_builder_from_context(context.ptr))
+        let configured = try guardNotNull(c2pa_builder_with_definition(base, manifestJSON))
+        self.init(adopting: configured)
+    }
+
+    /// Creates a new builder from a ``C2PAContext`` and a ``ManifestDefinition``.
+    ///
+    /// Validates the manifest before construction. Errors cause a throw;
+    /// warnings are logged via `NSLog`.
+    ///
+    /// - Parameters:
+    ///   - context: The ``C2PAContext`` providing shared configuration.
+    ///   - manifest: The manifest definition to build.
+    ///
+    /// - Throws: ``C2PAError/manifestValidationFailed(_:)`` if validation finds errors,
+    ///   or ``C2PAError`` if the JSON cannot be parsed by the C layer.
+    ///
+    /// - SeeAlso: ``C2PAContext``, ``ManifestDefinition``
+    public convenience init(context: C2PAContext, manifest: ManifestDefinition) throws {
+        try Self.enforce(ManifestValidator.validate(manifest))
+        try self.init(context: context, manifestJSON: manifest.toJSON())
     }
 
     deinit { c2pa_builder_free(ptr) }

--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -1,0 +1,160 @@
+// This file is licensed to you under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+// (http://opensource.org/licenses/MIT), at your option.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+// ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+// files for the specific language governing permissions and limitations under
+// each license.
+//
+//  C2PAContext.swift
+//
+
+import C2PAC
+import Foundation
+
+/// An immutable, shareable configuration context for creating builders.
+///
+/// `C2PAContext` wraps the native context produced by ``C2PAContextBuilder``.
+/// Once built, a context is immutable and can be used to create one or more
+/// ``Builder`` instances that share the same configuration (settings such as
+/// created-assertion labels, trust configuration, and CAWG signer settings).
+///
+/// ## Topics
+///
+/// ### Creating a Context
+/// - ``init()``
+/// - ``init(settings:)``
+///
+/// ### Controlling Operations
+/// - ``cancel()``
+///
+/// ## Example
+///
+/// ```swift
+/// let settings = try C2PASettings(json: settingsJSON)
+/// let context = try C2PAContext(settings: settings)
+/// let builder = try Builder(context: context, manifestJSON: manifestJSON)
+/// ```
+///
+/// - SeeAlso: ``C2PAContextBuilder``, ``C2PASettings``, ``Builder``
+public final class C2PAContext {
+    let ptr: UnsafeMutablePointer<C2paContext>
+
+    /// Internal initializer that adopts an already-built native context.
+    init(ptr: UnsafeMutablePointer<C2paContext>) {
+        self.ptr = ptr
+    }
+
+    /// Creates a context with default settings.
+    ///
+    /// - Throws: ``C2PAError`` if the context cannot be created.
+    public convenience init() throws {
+        self.init(ptr: try guardNotNull(c2pa_context_new()))
+    }
+
+    /// Creates a context configured with the given settings.
+    ///
+    /// The settings are cloned by the C layer, so the caller retains ownership
+    /// of `settings`.
+    ///
+    /// - Parameter settings: The ``C2PASettings`` to configure this context with.
+    ///
+    /// - Throws: ``C2PAError`` if the context cannot be created.
+    public convenience init(settings: C2PASettings) throws {
+        let builder = try C2PAContextBuilder()
+        try builder.setSettings(settings)
+        self.init(ptr: try builder.buildPtr())
+    }
+
+    deinit { _ = c2pa_free(ptr) }
+
+    /// Requests cancellation of any in-progress signing or reading operation
+    /// running on this context.
+    ///
+    /// - Throws: ``C2PAError`` if the cancellation request fails.
+    public func cancel() throws {
+        _ = try guardNonNegative(Int64(c2pa_context_cancel(ptr)))
+    }
+}
+
+/// A configurable builder that produces an immutable ``C2PAContext``.
+///
+/// Use `C2PAContextBuilder` when you need to apply settings before building a
+/// context. For the common cases, prefer the ``C2PAContext`` convenience
+/// initializers.
+///
+/// ## Topics
+///
+/// ### Building a Context
+/// - ``init()``
+/// - ``setSettings(_:)``
+/// - ``build()``
+///
+/// ## Example
+///
+/// ```swift
+/// let context = try C2PAContextBuilder()
+///     .setSettings(settings)
+///     .build()
+/// ```
+///
+/// - SeeAlso: ``C2PAContext``, ``C2PASettings``
+public final class C2PAContextBuilder {
+    private var ptr: UnsafeMutablePointer<C2paContextBuilder>?
+
+    /// Creates a new, empty context builder.
+    ///
+    /// - Throws: ``C2PAError`` if the builder cannot be created.
+    public init() throws {
+        self.ptr = try guardNotNull(c2pa_context_builder_new())
+    }
+
+    /// Applies settings to the context being built.
+    ///
+    /// The settings are cloned by the C layer, so the caller retains ownership.
+    ///
+    /// - Parameter settings: The ``C2PASettings`` to apply.
+    ///
+    /// - Returns: This builder, to allow chaining.
+    ///
+    /// - Throws: ``C2PAError`` if the builder has already been built, or the
+    ///   settings cannot be applied.
+    @discardableResult
+    public func setSettings(_ settings: C2PASettings) throws -> Self {
+        guard let ptr else {
+            throw C2PAError.api("Context builder has already been built")
+        }
+        _ = try guardNonNegative(
+            Int64(c2pa_context_builder_set_settings(ptr, settings.rawPtr))
+        )
+        return self
+    }
+
+    /// Builds an immutable ``C2PAContext``.
+    ///
+    /// This consumes the builder; the builder must not be reused afterward.
+    ///
+    /// - Returns: The configured ``C2PAContext``.
+    ///
+    /// - Throws: ``C2PAError`` if the builder has already been built, or the
+    ///   context cannot be created.
+    public func build() throws -> C2PAContext {
+        C2PAContext(ptr: try buildPtr())
+    }
+
+    /// Consumes the native builder and returns the built context pointer.
+    func buildPtr() throws -> UnsafeMutablePointer<C2paContext> {
+        guard let ptr else {
+            throw C2PAError.api("Context builder has already been built")
+        }
+        let context = try guardNotNull(c2pa_context_builder_build(ptr))
+        self.ptr = nil  // the native builder is consumed by build()
+        return context
+    }
+
+    deinit {
+        if let ptr { _ = c2pa_free(ptr) }
+    }
+}

--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -75,7 +75,9 @@ public final class C2PAContext {
     ///
     /// - Throws: ``C2PAError`` if the cancellation request fails.
     public func cancel() throws {
-        _ = try guardNonNegative(Int64(c2pa_context_cancel(ptr)))
+        guard c2pa_context_cancel(ptr) == 0 else {
+            throw C2PAError.api(lastC2PAError())
+        }
     }
 }
 
@@ -149,9 +151,8 @@ public final class C2PAContextBuilder {
         guard let ptr else {
             throw C2PAError.api("Context builder has already been built")
         }
-        let context = try guardNotNull(c2pa_context_builder_build(ptr))
-        self.ptr = nil  // the native builder is consumed by build()
-        return context
+        self.ptr = nil  // c2pa_context_builder_build consumes the builder, even on error
+        return try guardNotNull(c2pa_context_builder_build(ptr))
     }
 
     deinit {

--- a/Library/Sources/C2PASettings.swift
+++ b/Library/Sources/C2PASettings.swift
@@ -45,6 +45,10 @@ import Foundation
 public final class C2PASettings {
     private var settingsString: String
     private var format: String
+    private let ptr: UnsafeMutablePointer<C2paSettings>
+
+    /// The native settings handle, used to configure a ``C2PAContextBuilder``.
+    var rawPtr: UnsafeMutablePointer<C2paSettings> { ptr }
 
     /// Creates settings from a JSON string.
     ///
@@ -53,7 +57,8 @@ public final class C2PASettings {
     public init(json: String) throws {
         self.settingsString = json
         self.format = "json"
-        try apply()
+        self.ptr = try guardNotNull(c2pa_settings_new())
+        try update()
     }
 
     /// Creates settings from a TOML string.
@@ -63,7 +68,8 @@ public final class C2PASettings {
     public init(toml: String) throws {
         self.settingsString = toml
         self.format = "toml"
-        try apply()
+        self.ptr = try guardNotNull(c2pa_settings_new())
+        try update()
     }
 
     /// Creates settings from a type-safe ``C2PASettingsDefinition``.
@@ -77,8 +83,11 @@ public final class C2PASettings {
     public init(definition: C2PASettingsDefinition) throws {
         self.settingsString = try C2PAJson.encode(definition)
         self.format = "json"
-        try apply()
+        self.ptr = try guardNotNull(c2pa_settings_new())
+        try update()
     }
+
+    deinit { _ = c2pa_free(ptr) }
 
     /// Loads additional JSON settings, merging with existing configuration.
     ///
@@ -87,7 +96,7 @@ public final class C2PASettings {
     public func load(json: String) throws {
         self.settingsString = json
         self.format = "json"
-        try apply()
+        try update()
     }
 
     /// Loads additional TOML settings, merging with existing configuration.
@@ -97,7 +106,7 @@ public final class C2PASettings {
     public func load(toml: String) throws {
         self.settingsString = toml
         self.format = "toml"
-        try apply()
+        try update()
     }
 
     /// Loads settings from a type-safe ``C2PASettingsDefinition``,
@@ -108,7 +117,7 @@ public final class C2PASettings {
     public func load(definition: C2PASettingsDefinition) throws {
         self.settingsString = try C2PAJson.encode(definition)
         self.format = "json"
-        try apply()
+        try update()
     }
 
     /// Sets a single value at the given dot-separated path within the settings.
@@ -153,7 +162,7 @@ public final class C2PASettings {
         }
 
         self.settingsString = updatedString
-        try apply()
+        try update()
     }
 
     /// Creates a ``Signer`` from the loaded settings.
@@ -170,10 +179,10 @@ public final class C2PASettings {
 
     // MARK: - Private
 
-    private func apply() throws {
+    private func update() throws {
         try settingsString.withCString { settingsPtr in
             try format.withCString { formatPtr in
-                let result = c2pa_load_settings(settingsPtr, formatPtr)
+                let result = c2pa_settings_update_from_string(ptr, settingsPtr, formatPtr)
                 guard result == 0 else {
                     throw C2PAError.api(lastC2PAError())
                 }

--- a/Library/Sources/C2PASettings.swift
+++ b/Library/Sources/C2PASettings.swift
@@ -57,8 +57,7 @@ public final class C2PASettings {
     public init(json: String) throws {
         self.settingsString = json
         self.format = "json"
-        self.ptr = try guardNotNull(c2pa_settings_new())
-        try update()
+        self.ptr = try Self.makeHandle(from: json, format: "json")
     }
 
     /// Creates settings from a TOML string.
@@ -68,8 +67,7 @@ public final class C2PASettings {
     public init(toml: String) throws {
         self.settingsString = toml
         self.format = "toml"
-        self.ptr = try guardNotNull(c2pa_settings_new())
-        try update()
+        self.ptr = try Self.makeHandle(from: toml, format: "toml")
     }
 
     /// Creates settings from a type-safe ``C2PASettingsDefinition``.
@@ -81,12 +79,14 @@ public final class C2PASettings {
     ///
     /// - SeeAlso: ``C2PASettingsDefinition``
     public init(definition: C2PASettingsDefinition) throws {
-        self.settingsString = try C2PAJson.encode(definition)
+        let json = try C2PAJson.encode(definition)
+        self.settingsString = json
         self.format = "json"
-        self.ptr = try guardNotNull(c2pa_settings_new())
-        try update()
+        self.ptr = try Self.makeHandle(from: json, format: "json")
     }
 
+    // No type-specific c2pa_settings_free exists; c2pa_free is the documented
+    // general-purpose free and returns an int we intentionally discard.
     deinit { _ = c2pa_free(ptr) }
 
     /// Loads additional JSON settings, merging with existing configuration.
@@ -94,9 +94,9 @@ public final class C2PASettings {
     /// - Parameter json: A JSON string containing C2PA settings to merge.
     /// - Throws: ``C2PAError`` if the JSON is invalid.
     public func load(json: String) throws {
+        try Self.applyString(json, format: "json", to: ptr)
         self.settingsString = json
         self.format = "json"
-        try update()
     }
 
     /// Loads additional TOML settings, merging with existing configuration.
@@ -104,9 +104,9 @@ public final class C2PASettings {
     /// - Parameter toml: A TOML string containing C2PA settings to merge.
     /// - Throws: ``C2PAError`` if the TOML is invalid.
     public func load(toml: String) throws {
+        try Self.applyString(toml, format: "toml", to: ptr)
         self.settingsString = toml
         self.format = "toml"
-        try update()
     }
 
     /// Loads settings from a type-safe ``C2PASettingsDefinition``,
@@ -115,9 +115,10 @@ public final class C2PASettings {
     /// - Parameter definition: A settings definition struct.
     /// - Throws: ``C2PAError`` if the settings are invalid.
     public func load(definition: C2PASettingsDefinition) throws {
-        self.settingsString = try C2PAJson.encode(definition)
+        let json = try C2PAJson.encode(definition)
+        try Self.applyString(json, format: "json", to: ptr)
+        self.settingsString = json
         self.format = "json"
-        try update()
     }
 
     /// Sets a single value at the given dot-separated path within the settings.
@@ -161,8 +162,8 @@ public final class C2PASettings {
             throw C2PAError.utf8
         }
 
+        try Self.applyString(updatedString, format: "json", to: ptr)
         self.settingsString = updatedString
-        try update()
     }
 
     /// Creates a ``Signer`` from the loaded settings.
@@ -179,10 +180,32 @@ public final class C2PASettings {
 
     // MARK: - Private
 
-    private func update() throws {
-        try settingsString.withCString { settingsPtr in
+    /// Allocates a native settings handle and applies the given string,
+    /// freeing the handle if the update fails (a failed initializer does not
+    /// run `deinit`).
+    private static func makeHandle(
+        from string: String,
+        format: String
+    ) throws -> UnsafeMutablePointer<C2paSettings> {
+        let handle = try guardNotNull(c2pa_settings_new())
+        do {
+            try applyString(string, format: format, to: handle)
+        } catch {
+            _ = c2pa_free(handle)
+            throw error
+        }
+        return handle
+    }
+
+    /// Applies a settings string in the given format to a native handle.
+    private static func applyString(
+        _ string: String,
+        format: String,
+        to handle: UnsafeMutablePointer<C2paSettings>
+    ) throws {
+        try string.withCString { settingsPtr in
             try format.withCString { formatPtr in
-                let result = c2pa_settings_update_from_string(ptr, settingsPtr, formatPtr)
+                let result = c2pa_settings_update_from_string(handle, settingsPtr, formatPtr)
                 guard result == 0 else {
                     throw C2PAError.api(lastC2PAError())
                 }

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -907,6 +907,11 @@ final class ContextTests: XCTestCase {
         let result = tests.testContextCancel()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testBuilderFromContext() throws {
+        let result = tests.testBuilderFromContext()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Settings Definition Tests

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -893,16 +893,19 @@ final class AssertionDefinitionTests: XCTestCase {
 final class ContextTests: XCTestCase {
     private let tests = TestShared.ContextTests()
 
-    func testContextDefaultCreation() {
-        XCTAssertTrue(tests.testContextDefaultCreation().passed)
+    func testContextDefaultCreation() throws {
+        let result = tests.testContextDefaultCreation()
+        XCTAssertTrue(result.passed, result.message)
     }
 
-    func testContextFromSettings() {
-        XCTAssertTrue(tests.testContextFromSettings().passed)
+    func testContextFromSettings() throws {
+        let result = tests.testContextFromSettings()
+        XCTAssertTrue(result.passed, result.message)
     }
 
-    func testContextCancel() {
-        XCTAssertTrue(tests.testContextCancel().passed)
+    func testContextCancel() throws {
+        let result = tests.testContextCancel()
+        XCTAssertTrue(result.passed, result.message)
     }
 }
 

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -888,6 +888,24 @@ final class AssertionDefinitionTests: XCTestCase {
     }
 }
 
+// MARK: - Context Tests
+
+final class ContextTests: XCTestCase {
+    private let tests = TestShared.ContextTests()
+
+    func testContextDefaultCreation() {
+        XCTAssertTrue(tests.testContextDefaultCreation().passed)
+    }
+
+    func testContextFromSettings() {
+        XCTAssertTrue(tests.testContextFromSettings().passed)
+    }
+
+    func testContextCancel() {
+        XCTAssertTrue(tests.testContextCancel().passed)
+    }
+}
+
 // MARK: - Settings Definition Tests
 
 final class SettingsDefinitionTests: XCTestCase {

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -912,6 +912,11 @@ final class ContextTests: XCTestCase {
         let result = tests.testBuilderFromContext()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testSettingsFlowRoundtrip() throws {
+        let result = tests.testSettingsFlowRoundtrip()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Settings Definition Tests

--- a/TestApp/Sources/TestRunner.swift
+++ b/TestApp/Sources/TestRunner.swift
@@ -59,6 +59,8 @@ public final class TestRunner: Sendable {
             return await AssertionDefinitionTests().runAllTests()
         case .settingsDefinition:
             return await SettingsDefinitionTests().runAllTests()
+        case .context:
+            return await ContextTests().runAllTests()
         case .convenience:
             return await ConvenienceTests().runAllTests()
         }
@@ -81,6 +83,7 @@ public enum TestSuite: String, CaseIterable, Sendable {
     case manifest = "Manifest"
     case assertionDefinition = "Assertion Definition"
     case settingsDefinition = "Settings Definition"
+    case context = "Context"
     case convenience = "Convenience"
 
     public var displayName: String {

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -45,11 +45,23 @@ public final class ContextTests: TestImplementation {
         }
     }
 
+    public func testBuilderFromContext() -> TestResult {
+        do {
+            let manifestJSON = TestUtilities.createTestManifestJSON()
+            let context = try C2PAContext()
+            _ = try Builder(context: context, manifestJSON: manifestJSON)
+            return .success("Builder From Context", "[PASS] Created Builder from context")
+        } catch {
+            return .failure("Builder From Context", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         [
             testContextDefaultCreation(),
             testContextFromSettings(),
             testContextCancel(),
+            testBuilderFromContext(),
         ]
     }
 }

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -1,0 +1,55 @@
+// This file is licensed to you under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+// (http://opensource.org/licenses/MIT), at your option.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+// ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+// files for the specific language governing permissions and limitations under
+// each license.
+
+import C2PA
+import Foundation
+
+// Context API tests - pure Swift implementation
+public final class ContextTests: TestImplementation {
+
+    public init() {}
+
+    public func testContextDefaultCreation() -> TestResult {
+        do {
+            _ = try C2PAContext()
+            return .success("Context Default Creation", "[PASS] Created default C2PAContext")
+        } catch {
+            return .failure("Context Default Creation", "Error: \(error)")
+        }
+    }
+
+    public func testContextFromSettings() -> TestResult {
+        do {
+            let settings = try C2PASettings(json: "{\"version\": 1}")
+            _ = try C2PAContext(settings: settings)
+            return .success("Context From Settings", "[PASS] Created C2PAContext from settings")
+        } catch {
+            return .failure("Context From Settings", "Error: \(error)")
+        }
+    }
+
+    public func testContextCancel() -> TestResult {
+        do {
+            let context = try C2PAContext()
+            try context.cancel()
+            return .success("Context Cancel", "[PASS] cancel() returned without error")
+        } catch {
+            return .failure("Context Cancel", "Error: \(error)")
+        }
+    }
+
+    public func runAllTests() async -> [TestResult] {
+        [
+            testContextDefaultCreation(),
+            testContextFromSettings(),
+            testContextCancel(),
+        ]
+    }
+}

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -56,12 +56,72 @@ public final class ContextTests: TestImplementation {
         }
     }
 
+    public func testSettingsFlowRoundtrip() -> TestResult {
+        let manifestJSON = TestUtilities.createTestManifestJSON()
+        let settingsJSON = "{\"version\": 1, \"verify\": {\"verify_after_reading\": true}}"
+
+        do {
+            let settings = try C2PASettings(json: settingsJSON)
+            let context = try C2PAContext(settings: settings)
+            let builder = try Builder(context: context, manifestJSON: manifestJSON)
+
+            let tempDir = FileManager.default.temporaryDirectory
+            let sourceFile = tempDir.appendingPathComponent("ctx_source_\(UUID().uuidString).jpg")
+            let destFile = tempDir.appendingPathComponent("ctx_dest_\(UUID().uuidString).jpg")
+            defer {
+                try? FileManager.default.removeItem(at: sourceFile)
+                try? FileManager.default.removeItem(at: destFile)
+            }
+
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure("Settings Flow Roundtrip", "Could not load test image")
+            }
+            try imageData.write(to: sourceFile)
+
+            let sourceStream = try Stream(readFrom: sourceFile)
+            let destStream = try Stream(writeTo: destFile)
+            let signer = try TestUtilities.createTestSigner()
+
+            _ = try builder.sign(
+                format: "image/jpeg",
+                source: sourceStream,
+                destination: destStream,
+                signer: signer
+            )
+
+            if FileManager.default.fileExists(atPath: destFile.path),
+               let readManifest = try? C2PA.readFile(at: destFile),
+               !readManifest.isEmpty
+            {
+                return .success(
+                    "Settings Flow Roundtrip",
+                    "[PASS] settings -> context -> builder -> sign -> read round-trips"
+                )
+            }
+            return .failure("Settings Flow Roundtrip", "Signed file missing or unreadable")
+        } catch let error as C2PAError {
+            if case .api(let message) = error,
+               message.contains("certificate") || message.contains("cert")
+                || message.contains("key") || message.contains("signing")
+            {
+                return .success(
+                    "Settings Flow Roundtrip",
+                    "[WARN] context+settings path works (cert/key error expected: \(message))"
+                )
+            }
+            return .failure("Settings Flow Roundtrip", "C2PAError: \(error)")
+        } catch {
+            return .failure("Settings Flow Roundtrip", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         [
             testContextDefaultCreation(),
             testContextFromSettings(),
             testContextCancel(),
             testBuilderFromContext(),
+            testSettingsFlowRoundtrip(),
         ]
     }
 }

--- a/TestShared/TestShared.xcodeproj/project.pbxproj
+++ b/TestShared/TestShared.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		95COV0102E9700000000008 /* SettingsDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95COV0112E9700000000008 /* SettingsDefinitionTests.swift */; };
 		95F2712B2E72CD5800A6A88D /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 95F271292E72CD5800A6A88D /* Base.xcconfig */; };
 		A0B3CF4F2E96AC2C00F2F938 /* ManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B3CF4E2E96AC2C00F2F938 /* ManifestTests.swift */; };
-		A0CTX0032E9700000000002 /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CTX0042E9700000000002 /* ContextTests.swift */; };
+		C20AC07E97000000000B0003 /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20AC07E97000000000B0004 /* ContextTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -75,7 +75,7 @@
 		95COV0112E9700000000008 /* SettingsDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDefinitionTests.swift; sourceTree = "<group>"; };
 		95F271292E72CD5800A6A88D /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		A0B3CF4E2E96AC2C00F2F938 /* ManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestTests.swift; sourceTree = "<group>"; };
-		A0CTX0042E9700000000002 /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
+		C20AC07E97000000000B0004 /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,7 +114,7 @@
 			children = (
 				95COV00E2E9700000000007 /* AssertionDefinitionTests.swift */,
 				95C99A4F2E695DF100C54D0E /* BuilderTests.swift */,
-				A0CTX0042E9700000000002 /* ContextTests.swift */,
+				C20AC07E97000000000B0004 /* ContextTests.swift */,
 				95COV0082E9700000000004 /* ConvenienceTests.swift */,
 				95COV0022E9700000000001 /* CertificateManagerTests.swift */,
 				95C99A502E695DF100C54D0E /* ComprehensiveTests.swift */,
@@ -253,7 +253,7 @@
 			files = (
 				95COV00D2E9700000000007 /* AssertionDefinitionTests.swift in Sources */,
 				95C99A572E695DF100C54D0E /* BuilderTests.swift in Sources */,
-				A0CTX0032E9700000000002 /* ContextTests.swift in Sources */,
+				C20AC07E97000000000B0003 /* ContextTests.swift in Sources */,
 				95COV0072E9700000000004 /* ConvenienceTests.swift in Sources */,
 				95COV0012E9700000000001 /* CertificateManagerTests.swift in Sources */,
 				95C99A562E695DF100C54D0E /* ComprehensiveTests.swift in Sources */,

--- a/TestShared/TestShared.xcodeproj/project.pbxproj
+++ b/TestShared/TestShared.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		95COV0102E9700000000008 /* SettingsDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95COV0112E9700000000008 /* SettingsDefinitionTests.swift */; };
 		95F2712B2E72CD5800A6A88D /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 95F271292E72CD5800A6A88D /* Base.xcconfig */; };
 		A0B3CF4F2E96AC2C00F2F938 /* ManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B3CF4E2E96AC2C00F2F938 /* ManifestTests.swift */; };
+		A0CTX0032E9700000000002 /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CTX0042E9700000000002 /* ContextTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -74,6 +75,7 @@
 		95COV0112E9700000000008 /* SettingsDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDefinitionTests.swift; sourceTree = "<group>"; };
 		95F271292E72CD5800A6A88D /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		A0B3CF4E2E96AC2C00F2F938 /* ManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestTests.swift; sourceTree = "<group>"; };
+		A0CTX0042E9700000000002 /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +114,7 @@
 			children = (
 				95COV00E2E9700000000007 /* AssertionDefinitionTests.swift */,
 				95C99A4F2E695DF100C54D0E /* BuilderTests.swift */,
+				A0CTX0042E9700000000002 /* ContextTests.swift */,
 				95COV0082E9700000000004 /* ConvenienceTests.swift */,
 				95COV0022E9700000000001 /* CertificateManagerTests.swift */,
 				95C99A502E695DF100C54D0E /* ComprehensiveTests.swift */,
@@ -250,6 +253,7 @@
 			files = (
 				95COV00D2E9700000000007 /* AssertionDefinitionTests.swift in Sources */,
 				95C99A572E695DF100C54D0E /* BuilderTests.swift in Sources */,
+				A0CTX0032E9700000000002 /* ContextTests.swift in Sources */,
 				95COV0072E9700000000004 /* ConvenienceTests.swift in Sources */,
 				95COV0012E9700000000001 /* CertificateManagerTests.swift in Sources */,
 				95C99A562E695DF100C54D0E /* ComprehensiveTests.swift in Sources */,


### PR DESCRIPTION
Commit 1 of the GP-290 series bringing c2pa-ios up to parity with the Android wrapper.

## What this adds
- **`C2PAContext` + `C2PAContextBuilder`** (`Library/Sources/C2PAContext.swift`) over `c2pa_context_builder_new`/`set_settings`/`build`, a default `c2pa_context_new` path, and `C2PAContext.cancel()`.
- **`C2PASettings` refactored** onto a native `c2pa_settings_new()` handle; init/load/setValue route through `c2pa_settings_update_from_string`. The deprecated process-global `c2pa_load_settings` apply is removed.
- **`Builder` context initializers** `init(context:manifestJSON:)` and validated `init(context:manifest:)` over `c2pa_builder_from_context` + `c2pa_builder_with_definition`.
- Tests: `ContextTests` (creation, builder-from-context, cancel, settings→context→builder→sign→read roundtrip) wired into the XCTest bridge, TestApp runner, and both `.pbxproj`.

## Proofmode parity (now expressible on iOS)
```swift
let settings = try C2PASettings(json: settingsJSONString)
let context  = try C2PAContext(settings: settings)
let builder  = try Builder(context: context, manifestJSON: manifestJSON)
```

## Deferred
- Context-level `set_signer` (consumes the signer pointer; signer flows via settings or `builder.sign(signer:)`) and the progress-callback / HTTP-resolver callbacks → GP-292.

## Verification
`make test-library` passes.

Linear: GP-291