### PR TITLE
refactor: migrate off deprecated read/sign FFI (GP-293)

### DIFF
--- a/ExampleApp/Sources/C2PAManager.swift
+++ b/ExampleApp/Sources/C2PAManager.swift
@@ -121,7 +121,7 @@ final class C2PAManager: ObservableObject {
                 os_log("Starting C2PA verification of saved file...", log: Logger.verification, type: .info)
                 do {
                     // Read the file back and verify C2PA credentials
-                    let manifestJSON = try C2PA.readFile(at: savedURL, dataDir: nil)
+                    let manifestJSON = try C2PA.readFile(at: savedURL)
 
                     os_log("C2PA VERIFICATION SUCCESS", log: Logger.verification, type: .info)
                     os_log("Manifest JSON loaded successfully", log: Logger.verification, type: .info)

--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -273,8 +273,6 @@ public final class Builder {
     ///   - stream: A ``Stream`` containing the ingredient file data.
     ///
     /// - Throws: ``C2PAError`` if the ingredient cannot be added.
-    ///
-    /// - SeeAlso: ``C2PA/readIngredient(at:dataDir:)``
     public func addIngredient(json: String, format: String, from stream: Stream) throws {
         _ = try guardNonNegative(
             Int64(c2pa_builder_add_ingredient_from_stream(ptr, json, format, stream.rawPtr))

--- a/Library/Sources/C2PA.docc/C2PA.md
+++ b/Library/Sources/C2PA.docc/C2PA.md
@@ -12,13 +12,12 @@ The library wraps the Rust-based C2PA implementation via C bindings, providing a
 
 ### Reading Content Credentials
 
-- ``C2PA/readFile(at:dataDir:)``
-- ``C2PA/readIngredient(at:dataDir:)``
+- ``C2PA/readFile(at:)``
 - ``Reader``
 
 ### Creating and Signing Content
 
-- ``C2PA/signFile(source:destination:manifestJSON:signerInfo:dataDir:)``
+- ``C2PA/signFile(source:destination:manifestJSON:signerInfo:)``
 - ``Builder``
 - ``Signer``
 

--- a/Library/Sources/C2PA.swift
+++ b/Library/Sources/C2PA.swift
@@ -22,11 +22,10 @@ import Foundation
 /// ## Topics
 ///
 /// ### Reading Manifests
-/// - ``readFile(at:dataDir:)``
-/// - ``readIngredient(at:dataDir:)``
+/// - ``readFile(at:)``
 ///
 /// ### Signing Files
-/// - ``signFile(source:destination:manifestJSON:signerInfo:dataDir:)``
+/// - ``signFile(source:destination:manifestJSON:signerInfo:)``
 public enum C2PA {
 
     public static var version: String {
@@ -37,148 +36,62 @@ public enum C2PA {
 
     /// Reads the C2PA manifest from a file and returns it as JSON.
     ///
-    /// This method extracts and validates the C2PA manifest embedded in a media file,
-    /// returning the manifest data as a JSON string.
+    /// Opens the file as a stream, infers its MIME type from the file extension,
+    /// and returns the embedded manifest as a JSON string.
     ///
-    /// - Parameters:
-    ///   - url: The URL of the file to read the manifest from.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
+    /// - Parameter url: The URL of the file to read the manifest from.
     ///
     /// - Returns: A JSON string containing the C2PA manifest data.
     ///
-    /// - Throws: ``C2PAError`` if the file cannot be read, has no manifest, or contains invalid data.
+    /// - Throws: ``C2PAError`` if the file cannot be read, the type is unknown,
+    ///   or it contains no valid manifest.
     ///
     /// ## Example
     ///
     /// ```swift
-    /// do {
-    ///     let manifestJSON = try C2PA.readFile(at: imageURL)
-    ///     print("Manifest: \(manifestJSON)")
-    /// } catch {
-    ///     print("Failed to read manifest: \(error)")
-    /// }
+    /// let manifestJSON = try C2PA.readFile(at: imageURL)
     /// ```
-    ///
-    /// - SeeAlso: ``readIngredient(at:dataDir:)``
-    public static func readFile(
-        at url: URL,
-        dataDir: URL? = nil
-    ) throws -> String {
-        try stringFromC(
-            c2pa_read_file(url.path, dataDir?.path)
-        )
-    }
-
-    /// Reads ingredient information from a file that will be used in a C2PA manifest.
-    ///
-    /// This method extracts information about a media file that will be referenced as an
-    /// ingredient (source material) in a new C2PA manifest. Ingredients represent the
-    /// original or modified content used to create a new asset.
-    ///
-    /// - Parameters:
-    ///   - url: The URL of the ingredient file to read.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
-    ///
-    /// - Returns: A JSON string containing the ingredient information.
-    ///
-    /// - Throws: ``C2PAError`` if the file cannot be read or processed as an ingredient.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// do {
-    ///     let ingredientJSON = try C2PA.readIngredient(at: originalImageURL)
-    ///     // Use ingredientJSON when building a new manifest
-    /// } catch {
-    ///     print("Failed to read ingredient: \(error)")
-    /// }
-    /// ```
-    ///
-    /// - SeeAlso: ``readFile(at:dataDir:)``
-    public static func readIngredient(
-        at url: URL,
-        dataDir: URL? = nil
-    ) throws -> String {
-        let result = c2pa_read_ingredient_file(url.path, dataDir?.path)
-        guard let result = result else {
-            let errorMsg = lastC2PAError()
-            // TODO: This special case handling may be removable if the underlying C API
-            // is updated to handle NULL data_dir consistently with c2pa_read_file
-            if errorMsg.contains("null parameter data_dir") || errorMsg.contains("data_dir") {
-                throw C2PAError.ingredientDataNotFound(errorMsg)
-            }
-            throw C2PAError.api(errorMsg)
-        }
-        return try stringFromC(result)
+    public static func readFile(at url: URL) throws -> String {
+        let stream = try Stream(readFrom: url)
+        let format = try inferredMIMEType(for: url)
+        let reader = try Reader(format: format, stream: stream)
+        return try reader.json()
     }
 
     /// Signs a media file with a C2PA manifest using PEM-encoded certificates and keys.
     ///
-    /// This convenience method creates a signed copy of the source file with an embedded
-    /// C2PA manifest. The manifest contains assertions about the content, its provenance,
-    /// and is cryptographically signed using the provided credentials.
+    /// Streams the source through a context-based ``Builder`` and writes the signed
+    /// result to `destination`. The media format is inferred from the source extension.
     ///
     /// - Parameters:
     ///   - source: The URL of the source file to sign.
     ///   - destination: The URL where the signed file will be written.
     ///   - manifestJSON: A JSON string defining the C2PA manifest structure and assertions.
     ///   - signerInfo: The signing credentials including certificate chain and private key.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
     ///
-    /// - Throws: ``C2PAError`` if signing fails due to invalid inputs, I/O errors, or cryptographic issues.
+    /// - Throws: ``C2PAError`` if signing fails due to invalid inputs, I/O errors,
+    ///   an unknown file type, or cryptographic issues.
     ///
-    /// ## Example
+    /// - Note: For advanced scenarios (hardware-backed keys, streaming), use
+    ///   ``Builder`` with a ``Signer`` instance directly.
     ///
-    /// ```swift
-    /// let signerInfo = SignerInfo(
-    ///     certificatePEM: certPEM,
-    ///     privateKeyPEM: keyPEM,
-    ///     algorithm: .es256,
-    ///     tsa: URL(string: "http://timestamp.digicert.com")
-    /// )
-    ///
-    /// try C2PA.signFile(
-    ///     source: sourceURL,
-    ///     destination: destURL,
-    ///     manifestJSON: manifestJSON,
-    ///     signerInfo: signerInfo
-    /// )
-    /// ```
-    ///
-    /// - Note: For more advanced signing scenarios, including hardware-backed keys
-    ///   and streaming operations, use ``Builder`` with a ``Signer`` instance.
-    ///
-    /// - SeeAlso: ``Builder``, ``Signer``, ``SignerInfo``
+    /// - SeeAlso: ``Builder``, ``Signer``, ``SignerInfo``, ``C2PAContext``
     public static func signFile(
         source: URL,
         destination: URL,
         manifestJSON: String,
-        signerInfo: SignerInfo,
-        dataDir: URL? = nil
+        signerInfo: SignerInfo
     ) throws {
-        var maybeErr: UnsafeMutablePointer<CChar>?
-        withSignerInfo(
-            algorithm: signerInfo.algorithm.rawValue,
-            cert: signerInfo.certificatePEM,
-            key: signerInfo.privateKeyPEM,
-            tsa: signerInfo.tsa
-        ) { algPtr, certPtr, keyPtr, tsaPtr in
-            var sInfo = C2paSignerInfo(
-                alg: algPtr,
-                sign_cert: certPtr,
-                private_key: keyPtr,
-                ta_url: tsaPtr)
-            maybeErr = c2pa_sign_file(
-                source.path,
-                destination.path,
-                manifestJSON,
-                &sInfo,
-                dataDir?.path)
-        }
-
-        if let e = maybeErr {
-            let msg = try stringFromC(e)
-            throw C2PAError.api(msg)
-        }
+        let format = try inferredMIMEType(for: source)
+        let sourceStream = try Stream(readFrom: source)
+        let destStream = try Stream(writeTo: destination)
+        let signer = try Signer(info: signerInfo)
+        let builder = try Builder(context: C2PAContext(), manifestJSON: manifestJSON)
+        _ = try builder.sign(
+            format: format,
+            source: sourceStream,
+            destination: destStream,
+            signer: signer
+        )
     }
 }

--- a/Library/Sources/C2PAError.swift
+++ b/Library/Sources/C2PAError.swift
@@ -25,7 +25,6 @@ import Foundation
 /// - ``nilPointer``
 /// - ``utf8``
 /// - ``negative(_:)``
-/// - ``ingredientDataNotFound(_:)``
 /// - ``ed25519NotSupported``
 /// - ``keySearchFailed(_:_:_:)``
 /// - ``unsupportedAlgorithm(_:_:)``
@@ -52,11 +51,6 @@ public enum C2PAError: Error, LocalizedError {
     ///
     /// - Parameter value: The negative status value.
     case negative(_ value: Int64)
-
-    /// The underlying C API probably experienced a NULL data_dir.
-    ///
-    /// - Parameter original: Original error message from C API.
-    case ingredientDataNotFound(_ original: String)
 
     /// Ed25519 algorithm is not supported by the Keychain.
     case ed25519NotSupported
@@ -105,9 +99,6 @@ public enum C2PAError: Error, LocalizedError {
 
         case .negative(let value):
             return "C2PA negative status \(value)"
-
-        case .ingredientDataNotFound(let original):
-            return "No ingredient data found: \(original)"
 
         case .ed25519NotSupported:
             return "Ed25519 not supported by Keychain"

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -13,6 +13,7 @@
 
 import C2PAC
 import Foundation
+import UniformTypeIdentifiers
 
 @inline(__always)
 func stringFromC(_ p: UnsafeMutablePointer<CChar>?) throws -> String {
@@ -82,4 +83,16 @@ func withOptionalCString<R>(
 @inline(__always)
 func asStreamCtx(_ p: UnsafeMutableRawPointer) -> UnsafeMutablePointer<StreamContext> {
     UnsafeMutablePointer<StreamContext>(OpaquePointer(p))
+}
+
+/// Infers the MIME type for a file URL from its path extension.
+///
+/// - Parameter url: The file URL whose extension determines the MIME type.
+/// - Returns: The preferred MIME type (e.g. `"image/jpeg"`).
+/// - Throws: ``C2PAError`` if the extension maps to no known type.
+func inferredMIMEType(for url: URL) throws -> String {
+    guard let mime = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType else {
+        throw C2PAError.api("Unsupported or unknown file type for extension '\(url.pathExtension)'")
+    }
+    return mime
 }

--- a/Library/Sources/Reader.swift
+++ b/Library/Sources/Reader.swift
@@ -60,7 +60,10 @@ public final class Reader {
     ///
     /// - Throws: ``C2PAError`` if the stream cannot be read or contains no valid manifest.
     public init(format: String, stream: Stream) throws {
-        ptr = try guardNotNull(c2pa_reader_from_stream(format, stream.rawPtr))
+        let context = try guardNotNull(c2pa_context_new())
+        defer { _ = c2pa_free(context) }
+        let base = try guardNotNull(c2pa_reader_from_context(context))
+        ptr = try guardNotNull(c2pa_reader_with_stream(base, format, stream.rawPtr))
     }
 
     /// Creates a reader from separate manifest data and media stream.
@@ -75,9 +78,13 @@ public final class Reader {
     ///
     /// - Throws: ``C2PAError`` if the manifest or stream cannot be processed.
     public init(format: String, stream: Stream, manifest: Data) throws {
+        let context = try guardNotNull(c2pa_context_new())
+        defer { _ = c2pa_free(context) }
+        let base = try guardNotNull(c2pa_reader_from_context(context))
         ptr = try manifest.withUnsafeBytes { buf in
             try guardNotNull(
-                c2pa_reader_from_manifest_data_and_stream(
+                c2pa_reader_with_manifest_data_and_stream(
+                    base,
                     format,
                     stream.rawPtr,
                     buf.bindMemory(to: UInt8.self).baseAddress!,

--- a/Library/Sources/Reader.swift
+++ b/Library/Sources/Reader.swift
@@ -20,7 +20,7 @@ import Foundation
 /// embedded in media files. Use this class when you need fine-grained control
 /// over reading operations or when working with stream-based I/O.
 ///
-/// For simple file-based reading, consider using ``C2PA/readFile(at:dataDir:)`` instead.
+/// For simple file-based reading, consider using ``C2PA/readFile(at:)`` instead.
 ///
 /// ## Topics
 ///
@@ -46,7 +46,7 @@ import Foundation
 /// print("Manifest: \(manifestJSON)")
 /// ```
 ///
-/// - SeeAlso: ``Stream``, ``C2PA/readFile(at:dataDir:)``
+/// - SeeAlso: ``Stream``, ``C2PA/readFile(at:)``
 public final class Reader {
     private let ptr: UnsafeMutablePointer<C2paReader>
 

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -338,18 +338,8 @@ final class ComprehensiveTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadIngredient() throws {
-        let result = tests.testReadIngredient()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
     func testInvalidFileHandling() throws {
         let result = tests.testInvalidFileHandling()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testFileOperationsWithDataDir() throws {
-        let result = tests.testFileOperationsWithDataDir()
         XCTAssertTrue(result.passed, result.message)
     }
 
@@ -670,11 +660,6 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadFileWithDataDir() throws {
-        let result = tests.testReadFileWithDataDir()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
     func testReadFileWithoutManifest() throws {
         let result = tests.testReadFileWithoutManifest()
         XCTAssertTrue(result.passed, result.message)
@@ -685,28 +670,13 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadIngredientWithManifest() throws {
-        let result = tests.testReadIngredientWithManifest()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testReadIngredientWithoutManifest() throws {
-        let result = tests.testReadIngredientWithoutManifest()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testReadIngredientWithoutDataDir() throws {
-        let result = tests.testReadIngredientWithoutDataDir()
+    func testReadFileUnknownExtension() throws {
+        let result = tests.testReadFileUnknownExtension()
         XCTAssertTrue(result.passed, result.message)
     }
 
     func testSignFile() throws {
         let result = tests.testSignFile()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testSignFileWithDataDir() throws {
-        let result = tests.testSignFileWithDataDir()
         XCTAssertTrue(result.passed, result.message)
     }
 

--- a/TestShared/Sources/ComprehensiveTests.swift
+++ b/TestShared/Sources/ComprehensiveTests.swift
@@ -379,61 +379,6 @@ public final class ComprehensiveTests: TestImplementation {
         }
     }
 
-    public func testReadIngredient() -> TestResult {
-        // Use Adobe test image which HAS a manifest (unlike Pexels which doesn't)
-        // This properly tests ingredient reading on a file with C2PA data
-        let testFile = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "ingredient_\(UUID().uuidString).jpg")
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("Read Ingredient", "Could not load Adobe test image")
-        }
-
-        do {
-            try imageData.write(to: testFile)
-            defer {
-                try? FileManager.default.removeItem(at: testFile)
-            }
-
-            let manifestJSON = try C2PA.readFile(at: testFile)
-
-            // Adobe image SHOULD have manifest
-            guard !manifestJSON.isEmpty else {
-                return .failure("Read Ingredient", "Adobe test image returned empty manifest")
-            }
-
-            let jsonData = Data(manifestJSON.utf8)
-            guard let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-                return .failure("Read Ingredient", "Failed to parse manifest JSON")
-            }
-
-            guard let manifests = json["manifests"] as? [String: Any] else {
-                return .failure("Read Ingredient", "No manifests field in Adobe test image")
-            }
-
-            // Check if any manifest has ingredients
-            var hasIngredients = false
-            for (_, manifest) in manifests {
-                if let m = manifest as? [String: Any],
-                    let ingredients = m["ingredients"] as? [[String: Any]],
-                    !ingredients.isEmpty
-                {
-                    hasIngredients = true
-                    break
-                }
-            }
-
-            // Adobe test image may or may not have ingredients, but we successfully checked
-            if hasIngredients {
-                return .success("Read Ingredient", "[PASS] Found ingredients in Adobe test image")
-            } else {
-                return .success("Read Ingredient", "[PASS] Adobe test image has manifest but no ingredients")
-            }
-
-        } catch {
-            return .failure("Read Ingredient", "Failed to read Adobe test image: \(error)")
-        }
-    }
-
     public func testInvalidFileHandling() -> TestResult {
         var testSteps: [String] = []
         let tempURL = FileManager.default.temporaryDirectory
@@ -456,62 +401,6 @@ public final class ComprehensiveTests: TestImplementation {
             testSteps.append("Error: \(error)")
 
             return .success("Invalid File Handling", testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testFileOperationsWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("File Operations with Data Dir", "Could not load test image")
-        }
-
-        let tempImageFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_image_\(UUID().uuidString).jpg")
-        let dataDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("c2pa_data_\(UUID().uuidString)")
-
-        do {
-            // Write test image
-            try imageData.write(to: tempImageFile)
-            defer {
-                try? FileManager.default.removeItem(at: tempImageFile)
-                try? FileManager.default.removeItem(at: dataDir)
-            }
-
-            // Create data directory
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-            testSteps.append("✓ Created data directory")
-
-            // Read file with data directory
-            let manifestJSON = try C2PA.readFile(at: tempImageFile, dataDir: dataDir)
-            if !manifestJSON.isEmpty {
-                testSteps.append("✓ Read manifest with data directory")
-            }
-
-            // Check if data directory has content
-            let contents = try FileManager.default.contentsOfDirectory(
-                at: dataDir,
-                includingPropertiesForKeys: nil)
-            if !contents.isEmpty {
-                testSteps.append("✓ Data directory contains \(contents.count) item(s)")
-            }
-
-            // Try reading ingredient with data directory
-            do {
-                let ingredientJSON = try C2PA.readIngredient(at: tempImageFile, dataDir: dataDir)
-                if !ingredientJSON.isEmpty {
-                    testSteps.append("✓ Found ingredient: \(ingredientJSON.count) bytes")
-                }
-            } catch {
-                testSteps.append("[WARN] No ingredient data (expected)")
-            }
-
-            return .success("File Operations with Data Dir", testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("✗ Failed: \(error)")
-            return .failure("File Operations with Data Dir", testSteps.joined(separator: "\n"))
         }
     }
 
@@ -579,7 +468,6 @@ public final class ComprehensiveTests: TestImplementation {
             testErrorHandling(),
             testReadImageWithManifest(),
             testInvalidFileHandling(),
-            testFileOperationsWithDataDir(),
             testStreamFileOptions(),
             testStreamFromData(),
             testStreamFromFile(),
@@ -591,8 +479,7 @@ public final class ComprehensiveTests: TestImplementation {
             testReaderWithTestImage(),
             testSigningAlgorithms(),
             testErrorEnumCases(),
-            testEndToEndSigning(),
-            testReadIngredient()
+            testEndToEndSigning()
         ]
     }
 }

--- a/TestShared/Sources/ComprehensiveTests.swift
+++ b/TestShared/Sources/ComprehensiveTests.swift
@@ -28,16 +28,11 @@ public final class ComprehensiveTests: TestImplementation {
         do {
             _ = try C2PA.readFile(at: URL(fileURLWithPath: "/non/existent/file.jpg"))
             return .failure("Error Handling", "Should have thrown an error")
-        } catch let error as C2PAError {
-            if case .api(let message) = error {
-                if message.contains("No such file") || message.contains("does not exist") || message.contains("Failed")
-                {
-                    return .success("Error Handling", "[PASS] Error handling works correctly")
-                }
-            }
-            return .failure("Error Handling", "Unexpected error: \(error)")
         } catch {
-            return .failure("Error Handling", "Unexpected error: \(error)")
+            // Reading a non-existent file must throw. Since readFile now opens a
+            // stream first, the error may be a Foundation file error (surfaced by
+            // the stream) rather than a C2PAError; either is acceptable here.
+            return .success("Error Handling", "[PASS] Error handling works correctly: \(error)")
         }
     }
 

--- a/TestShared/Sources/ConvenienceTests.swift
+++ b/TestShared/Sources/ConvenienceTests.swift
@@ -11,7 +11,7 @@
 import C2PA
 import Foundation
 
-// Tests for C2PA convenience methods (readFile, readIngredient, signFile)
+// Tests for C2PA convenience methods (readFile, signFile)
 public final class ConvenienceTests: TestImplementation {
 
     public init() {}
@@ -74,41 +74,6 @@ public final class ConvenienceTests: TestImplementation {
         }
     }
 
-    public func testReadFileWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readFile with DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-            testSteps.append("Created data directory: \(dataDir.path)")
-
-            let imageURL = tempDir.appendingPathComponent("test.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote image file")
-
-            let manifestJSON = try C2PA.readFile(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read manifest with dataDir parameter")
-            testSteps.append("Manifest length: \(manifestJSON.count) characters")
-
-            return .success(
-                "readFile with DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Error: \(error)")
-            return .failure(
-                "readFile with DataDir",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
     public func testReadFileWithoutManifest() -> TestResult {
         var testSteps: [String] = []
 
@@ -163,130 +128,6 @@ public final class ConvenienceTests: TestImplementation {
             return .success(
                 "readFile Non-existent File",
                 testSteps.joined(separator: "\n"))
-        }
-    }
-
-    // MARK: - C2PA.readIngredient Tests
-
-    public func testReadIngredientWithManifest() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readIngredient with Manifest", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("ingredient_data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let imageURL = tempDir.appendingPathComponent("ingredient.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image")
-
-            let ingredientJSON = try C2PA.readIngredient(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read ingredient successfully")
-            testSteps.append("Ingredient JSON length: \(ingredientJSON.count) characters")
-
-            guard !ingredientJSON.isEmpty else {
-                return .failure("readIngredient with Manifest", "Ingredient JSON is empty")
-            }
-
-            return .success(
-                "readIngredient with Manifest",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Error: \(error)")
-            return .failure(
-                "readIngredient with Manifest",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testReadIngredientWithoutManifest() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadPexelsTestImage() else {
-            return .failure("readIngredient without Manifest", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("ingredient_data_nomnfst")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let imageURL = tempDir.appendingPathComponent("no_manifest_ingredient.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image without manifest")
-
-            // readIngredient should still work for files without manifests
-            // (it extracts ingredient info, which is different from manifest)
-            let ingredientJSON = try C2PA.readIngredient(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read ingredient info for file without manifest")
-            testSteps.append("Ingredient JSON length: \(ingredientJSON.count) characters")
-
-            return .success(
-                "readIngredient without Manifest",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            // Files without manifest may or may not work with readIngredient
-            // The behavior depends on the C2PA library implementation
-            // This is a valid test path - just verify no crash occurred
-            testSteps.append("Error reading ingredient from file without manifest: \(error)")
-            testSteps.append("This behavior is acceptable - verifying no crash")
-            return .success(
-                "readIngredient without Manifest",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testReadIngredientWithoutDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readIngredient without DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        defer { cleanupTempDirectory(tempDir) }
-
-        let imageURL = tempDir.appendingPathComponent("ingredient_no_datadir.jpg")
-
-        do {
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image")
-
-            // Calling without dataDir - should throw an error since dataDir is required
-            _ = try C2PA.readIngredient(at: imageURL, dataDir: nil)
-
-            // If we get here without error, that's unexpected but not a test failure
-            // The API behavior may vary
-            testSteps.append("readIngredient succeeded without dataDir (unexpected)")
-            return .success(
-                "readIngredient without DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch let error as C2PAError {
-            // Expected: error because dataDir is required
-            testSteps.append("Caught expected C2PAError: \(error)")
-            if case .api(let message) = error {
-                testSteps.append("Error message: \(message)")
-            }
-            return .success(
-                "readIngredient without DataDir (correctly throws error)",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Caught non-C2PA error: \(error)")
-            return .failure(
-                "readIngredient without DataDir",
-                "Expected C2PAError but got: \(error)")
         }
     }
 
@@ -358,68 +199,6 @@ public final class ConvenienceTests: TestImplementation {
         }
     }
 
-    public func testSignFileWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadPexelsTestImage() else {
-            return .failure("signFile with DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("sign_data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let sourceURL = tempDir.appendingPathComponent("source_datadir.jpg")
-            let destURL = tempDir.appendingPathComponent("signed_datadir.jpg")
-
-            try imageData.write(to: sourceURL)
-            testSteps.append("Wrote source image")
-
-            let signerInfo = SignerInfo(
-                algorithm: .es256,
-                certificatePEM: TestUtilities.testCertsPEM,
-                privateKeyPEM: TestUtilities.testPrivateKeyPEM,
-                tsa: nil
-            )
-
-            let manifestJSON = TestUtilities.createTestManifestJSON(claimGenerator: "signFile_datadir_test/1.0")
-
-            try C2PA.signFile(
-                source: sourceURL,
-                destination: destURL,
-                manifestJSON: manifestJSON,
-                signerInfo: signerInfo,
-                dataDir: dataDir
-            )
-            testSteps.append("signFile with dataDir completed successfully")
-
-            guard FileManager.default.fileExists(atPath: destURL.path) else {
-                return .failure("signFile with DataDir", "Signed file was not created")
-            }
-            testSteps.append("Signed file created successfully")
-
-            return .success(
-                "signFile with DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch let error as C2PAError {
-            // The convenience API with dataDir may have different behavior
-            // Test verifies the API is callable; actual signing may fail due to test certificate limitations
-            testSteps.append("C2PAError with dataDir parameter: \(error)")
-            return .success(
-                "signFile with DataDir",
-                "[WARN] Convenience API with dataDir threw C2PAError (may be expected): " + testSteps.joined(separator: "\n"))
-        } catch {
-            testSteps.append("Environment error: \(error)")
-            return .success(
-                "signFile with DataDir",
-                "[WARN] Environment issue: " + testSteps.joined(separator: "\n"))
-        }
-    }
-
     public func testSignFileWithInvalidManifest() -> TestResult {
         var testSteps: [String] = []
 
@@ -481,18 +260,27 @@ public final class ConvenienceTests: TestImplementation {
             "No invalid manifests were rejected: " + testSteps.joined(separator: ", "))
     }
 
+    public func testReadFileUnknownExtension() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let weird = tempDir.appendingPathComponent("c2pa_unknown_\(UUID().uuidString).zzz")
+        defer { try? FileManager.default.removeItem(at: weird) }
+        do {
+            try Data([0x00, 0x01]).write(to: weird)
+            _ = try C2PA.readFile(at: weird)
+            return .failure("readFile Unknown Extension", "Expected an error for unknown extension")
+        } catch {
+            return .success("readFile Unknown Extension", "[PASS] readFile throws on unknown extension")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         var results: [TestResult] = []
 
         results.append(testReadFileWithManifest())
-        results.append(testReadFileWithDataDir())
         results.append(testReadFileWithoutManifest())
         results.append(testReadFileNonExistent())
-        results.append(testReadIngredientWithManifest())
-        results.append(testReadIngredientWithoutManifest())
-        results.append(testReadIngredientWithoutDataDir())
+        results.append(testReadFileUnknownExtension())
         results.append(testSignFile())
-        results.append(testSignFileWithDataDir())
         results.append(testSignFileWithInvalidManifest())
 
         return results


### PR DESCRIPTION
Commit 2 of the GP-290 series. **Stacked on #81 (`feature/gp-291`)** — review/merge that first; this PR's base will retarget to `main` once #81 lands.

Migrates iOS off the deprecated read/sign-path FFI so the build links cleanly against c2pa-rs 0.88.0, routing everything through the GP-291 context/stream API.

## Changes
- **`inferredMIMEType(for:)`** helper (UniformTypeIdentifiers) for extension→MIME.
- **`Reader`** both initializers migrated to `c2pa_context_new` + `c2pa_reader_from_context` + `c2pa_reader_with_stream` / `c2pa_reader_with_manifest_data_and_stream` (public API unchanged).
- **`C2PA.readFile(at:)`** and **`C2PA.signFile(source:destination:manifestJSON:signerInfo:)`** reimplemented over streams + the context-based `Builder`. **`dataDir` params removed.**
- **`C2PA.readIngredient`** removed (no stream FFI returns standalone ingredient JSON); unused `C2PAError.ingredientDataNotFound` removed.
- Test/doc fallout: deleted obsolete ingredient/dataDir tests + bridges, added an unknown-extension test, fixed stale DocC links, updated the ExampleApp call site, and relaxed `testErrorHandling` (a missing file now throws a Foundation error rather than a `C2PAError`).

## Verification
`make test-library` passes.

## Note
`Reader`/`Builder`/`Signer` `deinit` still use deprecated type-specific frees (`c2pa_reader_free`, etc.) — still link in 0.88.0; a frees→`c2pa_free` cleanup is a planned follow-up, out of scope here.

Linear: GP-293