### PR TITLE
refactor: migrate deprecated frees to c2pa_free (GP-298)

### DIFF
--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -176,7 +176,7 @@ public final class Builder {
         try self.init(context: context, manifestJSON: manifest.toJSON())
     }
 
-    deinit { c2pa_builder_free(ptr) }
+    deinit { _ = c2pa_free(ptr) }
 
     /// Sets the builder intent, specifying what kind of manifest to create.
     ///
@@ -410,7 +410,7 @@ public final class Builder {
         )
         guard let mp = manifestPtr else { return Data() }
         let data = Data(bytes: mp, count: Int(size))
-        c2pa_manifest_bytes_free(mp)
+        _ = c2pa_free(mp)
         return data
     }
 

--- a/Library/Sources/C2PA.swift
+++ b/Library/Sources/C2PA.swift
@@ -30,7 +30,7 @@ public enum C2PA {
 
     public static var version: String {
         let p = c2pa_version()!
-        defer { c2pa_string_free(p) }
+        defer { _ = c2pa_free(p) }
         return String(cString: p)
     }
 

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -18,7 +18,7 @@ import UniformTypeIdentifiers
 @inline(__always)
 func stringFromC(_ p: UnsafeMutablePointer<CChar>?) throws -> String {
     guard let p else { throw C2PAError.api(lastC2PAError()) }
-    defer { c2pa_string_free(p) }
+    defer { _ = c2pa_free(p) }
     guard let s = String(validatingCString: p) else { throw C2PAError.utf8 }
     return s
 }
@@ -26,7 +26,7 @@ func stringFromC(_ p: UnsafeMutablePointer<CChar>?) throws -> String {
 @inline(__always)
 func lastC2PAError() -> String {
     guard let p = c2pa_error() else { return "Unknown C2PA error" }
-    defer { c2pa_string_free(p) }
+    defer { _ = c2pa_free(p) }
     return String(cString: p)
 }
 

--- a/Library/Sources/Reader.swift
+++ b/Library/Sources/Reader.swift
@@ -98,7 +98,7 @@ public final class Reader {
         }
     }
 
-    deinit { c2pa_reader_free(ptr) }
+    deinit { _ = c2pa_free(ptr) }
 
     /// Returns the manifest data as a JSON string.
     ///
@@ -181,7 +181,7 @@ public final class Reader {
         guard let cString = c2pa_reader_remote_url(ptr) else {
             return nil
         }
-        defer { c2pa_string_free(UnsafeMutablePointer(mutating: cString)) }
+        defer { _ = c2pa_free(cString) }
         return URL(string: String(cString: cString))
     }
 

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -372,7 +372,7 @@ public final class Signer {
     }
 
     deinit {
-        if !consumed { c2pa_signer_free(ptr) }
+        if !consumed { _ = c2pa_free(ptr) }
         retainedContext?.release()
     }
 

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -193,7 +193,7 @@ public final class ContextTests: TestImplementation {
             testSettingsFlowRoundtrip(),
             testProgressCallback(),
             testHTTPResolver(),
-            testURLSessionHTTPResolver(),
+            testURLSessionHTTPResolver()
         ]
     }
 }


### PR DESCRIPTION
Cleanup follow-up under GP-290. **Stacked on #86 (`feature/gp-292`)**. Replaces the deprecated type-specific free functions with the universal `c2pa_free` (the header's recommended free for all pointer types).

## Changes (8 sites, 5 files)
- `Reader.deinit` (`c2pa_reader_free`), `Builder.deinit` (`c2pa_builder_free`), `Signer.deinit` (`c2pa_signer_free`) → `_ = c2pa_free(ptr)`.
- `c2pa_string_free` in `Helpers.stringFromC`/`lastC2PAError`, `Reader.remote()`, `C2PA.version` → `c2pa_free`.
- `c2pa_manifest_bytes_free` in `Builder.sign` → `c2pa_free`.

Mechanical, behavior-preserving (`c2pa_free` aliases all of these; returns `int`, discarded). No deprecated type-specific free calls remain in `Library/Sources`. `make test-library` passes.

Linear: GP-298