### PR TITLE
Feature/cawg callback signing

### DIFF
--- a/Configurations/Base.xcconfig
+++ b/Configurations/Base.xcconfig
@@ -2,7 +2,7 @@
 // This file contains shared settings used across all targets and build scripts
 
 // The version of the C2PA Rust library to download from GitHub releases
-C2PA_VERSION = v0.85.2
+C2PA_VERSION = v0.90.0
 
 // GitHub organization that hosts the C2PA releases
 GITHUB_ORG = contentauth

--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -436,7 +436,7 @@ public final class Builder {
                 format,
                 source.rawPtr,
                 destination.rawPtr,
-                signer.ptr,
+                try signer.livePtr(),
                 &manifestPtr)
         )
         return manifestData(length: size, pointer: manifestPtr)
@@ -575,7 +575,7 @@ public final class Builder {
     ) throws -> Data {
         var out: UnsafePointer<UInt8>?
         let len = try guardNonNegative(c2pa_builder_sign_data_hashed_embeddable(
-            ptr, signer.ptr, dataHash, format, asset.rawPtr, &out))
+            ptr, try signer.livePtr(), dataHash, format, asset.rawPtr, &out))
         return manifestData(length: len, pointer: out)
     }
 

--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -29,6 +29,7 @@ import Foundation
 /// - ``init(archiveStream:)``
 /// - ``init(context:manifest:)``
 /// - ``init(context:manifestJSON:)``
+/// - ``init(context:archiveStream:)``
 ///
 /// ### Configuring the Manifest
 /// - ``setIntent(_:)``
@@ -141,14 +142,32 @@ public final class Builder {
         try self.init(validatedJSON: manifestJSON)
     }
 
-    /// Creates a new builder from a previously created C2PA archive stream.
+    /// Creates a new builder from a ``C2PAContext`` and a previously created C2PA archive stream.
+    ///
+    /// The builder inherits the context's configuration (settings), so values
+    /// such as created-assertion labels and trust configuration flow into the
+    /// signed manifest.
+    ///
+    /// - Parameters:
+    ///   - context: The ``C2PAContext`` providing shared configuration.
+    ///   - archiveStream: A ``Stream`` containing a C2PA archive.
+    ///
+    /// - Throws: ``C2PAError`` if the archive is invalid or cannot be read.
+    ///
+    /// - SeeAlso: ``C2PAContext``
+    public convenience init(context: C2PAContext, archiveStream: Stream) throws {
+        let base = try guardNotNull(c2pa_builder_from_context(context.ptr))
+        let configured = try guardNotNull(c2pa_builder_with_archive(base, archiveStream.rawPtr))
+        self.init(adopting: configured, context: context)
+    }
+
+    /// Creates a new builder from a previously created C2PA archive stream, using a default context.
     ///
     /// - Parameter archiveStream: A ``Stream`` containing a C2PA archive.
     ///
     /// - Throws: ``C2PAError`` if the archive is invalid or cannot be read.
-    public init(archiveStream: Stream) throws {
-        ptr = try guardNotNull(c2pa_builder_from_archive(archiveStream.rawPtr))
-        context = nil
+    public convenience init(archiveStream: Stream) throws {
+        try self.init(context: C2PAContext(), archiveStream: archiveStream)
     }
 
     /// Creates a new builder from a ``C2PAContext`` and a manifest JSON definition.

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -108,6 +108,20 @@ func manifestData(length: Int64, pointer: UnsafePointer<UInt8>?) -> Data {
     return Data(bytes: pointer, count: Int(length))
 }
 
+/// Invokes `body` with a NULL-terminated C string array built from `strings`
+/// (or `nil` when `strings` is empty). The array and its strings are valid only
+/// for the duration of `body`.
+func withCStringArray<R>(
+    _ strings: [String],
+    _ body: (UnsafePointer<UnsafePointer<CChar>?>?) throws -> R
+) rethrows -> R {
+    guard !strings.isEmpty else { return try body(nil) }
+    var cStrings: [UnsafePointer<CChar>?] = strings.map { UnsafePointer(strdup($0)) }
+    cStrings.append(nil)
+    defer { for p in cStrings where p != nil { free(UnsafeMutablePointer(mutating: p)) } }
+    return try cStrings.withUnsafeBufferPointer { try body($0.baseAddress) }
+}
+
 /// Infers the MIME type for a file URL from its path extension.
 ///
 /// - Parameter url: The file URL whose extension determines the MIME type.

--- a/Library/Sources/Reader.swift
+++ b/Library/Sources/Reader.swift
@@ -33,6 +33,7 @@ import Foundation
 /// ### Reading Manifest Data
 /// - ``json()``
 /// - ``detailedJSON()``
+/// - ``crJSON()``
 /// - ``remote()``
 /// - ``isEmbedded()``
 ///
@@ -186,6 +187,21 @@ public final class Reader {
     /// - SeeAlso: ``json()``
     public func detailedJSON() throws -> String {
         try stringFromC(c2pa_reader_detailed_json(ptr))
+    }
+
+    /// Returns the manifest as a crJSON string.
+    ///
+    /// crJSON is the CBOR-rendered JSON form of the manifest store.
+    /// 
+    /// It is primarily used for testing application conformance, but may evolve to have other uses.
+    ///
+    /// - Returns: A crJSON string for the manifest.
+    ///
+    /// - Throws: ``C2PAError`` if the manifest cannot be read or is invalid.
+    ///
+    /// - SeeAlso: ``json()``, ``detailedJSON()``
+    public func crJSON() throws -> String {
+        try stringFromC(c2pa_reader_crjson(ptr))
     }
 
     /// Returns the remote URL where the manifest is hosted, if available.

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -30,6 +30,7 @@ import Foundation
 /// - ``init(certsPEM:privateKeyPEM:algorithm:tsa:)``
 /// - ``init(info:)``
 /// - ``init(algorithm:certificateChainPEM:tsa:sign:)``
+/// - ``withCawgIdentity(_:identity:referencedAssertions:roles:)``
 ///
 /// ### Signing Operations
 /// - ``reserveSize()``
@@ -76,6 +77,12 @@ public final class Signer {
 
     let ptr: UnsafeMutablePointer<C2paSigner>
     private var retainedContext: Unmanaged<AnyObject>?
+    /// When true, the native signer was consumed by ``withCawgIdentity(_:identity:referencedAssertions:roles:)``
+    /// and must not be freed by this instance.
+    private var consumed = false
+    /// Input signers consumed into this combined signer; held so their callback contexts
+    /// outlive this signer and are released only after this signer is freed.
+    private var consumedSigners: [Signer] = []
 
     private init(ptr: UnsafeMutablePointer<C2paSigner>) {
         self.ptr = ptr
@@ -365,7 +372,7 @@ public final class Signer {
     }
 
     deinit {
-        _ = c2pa_free(ptr)
+        if !consumed { _ = c2pa_free(ptr) }
         retainedContext?.release()
     }
 
@@ -379,6 +386,40 @@ public final class Signer {
     /// - Throws: ``C2PAError`` if the size cannot be determined.
     public func reserveSize() throws -> Int {
         try Int(guardNonNegative(c2pa_signer_reserve_size(ptr)))
+    }
+
+    /// Combines a claim signer with an X.509 identity signer into a single signer that
+    /// emits a `cawg.identity` assertion alongside the C2PA claim signature.
+    ///
+    /// Both `claimSigner` and `identitySigner` are **consumed** by this call: ownership
+    /// transfers to the returned signer, and they must not be reused or signed with afterward.
+    ///
+    /// - Parameters:
+    ///   - claimSigner: The signer used to sign the C2PA claim. Consumed by this call.
+    ///   - identitySigner: The signer used to sign the X.509 identity assertion. Consumed by this call.
+    ///   - referencedAssertions: Names of assertions to reference in the identity assertion.
+    ///   - roles: The named actor's roles.
+    ///
+    /// - Returns: A combined ``Signer`` that emits a `cawg.identity` assertion.
+    ///
+    /// - Throws: ``C2PAError`` if the combined signer cannot be created.
+    public static func withCawgIdentity(
+        _ claimSigner: Signer,
+        identity identitySigner: Signer,
+        referencedAssertions: [String] = [],
+        roles: [String] = []
+    ) throws -> Signer {
+        claimSigner.consumed = true
+        identitySigner.consumed = true
+        let raw = try withCStringArray(referencedAssertions) { refs in
+            try withCStringArray(roles) { roleList in
+                try guardNotNull(
+                    c2pa_identity_signer_create(claimSigner.ptr, identitySigner.ptr, refs, roleList))
+            }
+        }
+        let combined = Signer(ptr: raw)
+        combined.consumedSigners = [claimSigner, identitySigner]
+        return combined
     }
 }
 

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -409,6 +409,24 @@ public final class Signer {
     /// Both `claimSigner` and `identitySigner` are **consumed** by this call: ownership
     /// transfers to the returned signer, and they must not be reused or signed with afterward.
     ///
+    /// Both parameters are `sending`: in Swift 6 language mode the compiler rejects call
+    /// sites that reuse an input after this call, pass the same instance for both
+    /// parameters, or pass a signer that is still referenced elsewhere (for example, one
+    /// stored in a property). The diagnostic reads "sending 'x' risks causing data
+    /// races"; the fix is to construct each input as a fresh local (or inline) and use
+    /// only the returned signer afterward. Code compiled in Swift 5 language mode falls
+    /// back to runtime guards, which throw ``C2PAError`` on reuse.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let combined = try Signer.withCawgIdentity(
+    ///     try Signer(certsPEM: claimCerts, privateKeyPEM: claimKey, algorithm: .es256),
+    ///     identity: try Signer(certsPEM: idCerts, privateKeyPEM: idKey, algorithm: .es256),
+    ///     referencedAssertions: ["c2pa.actions"]
+    /// )
+    /// ```
+    ///
     /// - Parameters:
     ///   - claimSigner: The signer used to sign the C2PA claim. Consumed by this call.
     ///   - identitySigner: The signer used to sign the X.509 identity assertion. Consumed by this call.
@@ -417,13 +435,17 @@ public final class Signer {
     ///
     /// - Returns: A combined ``Signer`` that emits a `cawg.identity` assertion.
     ///
-    /// - Throws: ``C2PAError`` if the combined signer cannot be created.
+    /// - Throws: ``C2PAError`` if the combined signer cannot be created, or if
+    ///   `claimSigner` and `identitySigner` are the same instance.
     public static func withCawgIdentity(
-        _ claimSigner: Signer,
-        identity identitySigner: Signer,
+        _ claimSigner: sending Signer,
+        identity identitySigner: sending Signer,
         referencedAssertions: [String] = [],
         roles: [String] = []
     ) throws -> Signer {
+        guard claimSigner !== identitySigner else {
+            throw C2PAError.api("claim and identity signers must be distinct instances")
+        }
         let claimPtr = try claimSigner.livePtr()
         let identityPtr = try identitySigner.livePtr()
         // The native call invalidates both inputs unconditionally, so mark them consumed

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -84,6 +84,21 @@ public final class Signer {
     /// outlive this signer and are released only after this signer is freed.
     private var consumedSigners: [Signer] = []
 
+    /// The native signer, validated as still owned by this instance.
+    ///
+    /// Use this instead of ``ptr`` wherever the pointer is handed to the C layer, so a
+    /// signer consumed by ``withCawgIdentity(_:identity:referencedAssertions:roles:)``
+    /// fails with a clear error rather than dereferencing memory it no longer owns.
+    ///
+    /// - Throws: ``C2PAError`` if this signer was consumed.
+    func livePtr() throws -> UnsafeMutablePointer<C2paSigner> {
+        guard !consumed else {
+            throw C2PAError.api(
+                "Signer was consumed by withCawgIdentity(_:identity:referencedAssertions:roles:) and cannot be reused")
+        }
+        return ptr
+    }
+
     private init(ptr: UnsafeMutablePointer<C2paSigner>) {
         self.ptr = ptr
     }
@@ -385,7 +400,7 @@ public final class Signer {
     ///
     /// - Throws: ``C2PAError`` if the size cannot be determined.
     public func reserveSize() throws -> Int {
-        try Int(guardNonNegative(c2pa_signer_reserve_size(ptr)))
+        try Int(guardNonNegative(c2pa_signer_reserve_size(livePtr())))
     }
 
     /// Combines a claim signer with an X.509 identity signer into a single signer that
@@ -409,12 +424,16 @@ public final class Signer {
         referencedAssertions: [String] = [],
         roles: [String] = []
     ) throws -> Signer {
+        let claimPtr = try claimSigner.livePtr()
+        let identityPtr = try identitySigner.livePtr()
+        // The native call invalidates both inputs unconditionally, so mark them consumed
+        // before it runs: on failure that leaks rather than risking a double free.
         claimSigner.consumed = true
         identitySigner.consumed = true
         let raw = try withCStringArray(referencedAssertions) { refs in
             try withCStringArray(roles) { roleList in
                 try guardNotNull(
-                    c2pa_identity_signer_create(claimSigner.ptr, identitySigner.ptr, refs, roleList))
+                    c2pa_identity_signer_create(claimPtr, identityPtr, refs, roleList))
             }
         }
         let combined = Signer(ptr: raw)

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -840,6 +840,16 @@ final class SignerExtendedTests: XCTestCase {
         let result = tests.testSignerCallbackErrorPropagation()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testCawgIdentitySigner() throws {
+        let result = tests.testCawgIdentitySigner()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testCawgIdentitySignerReserveSize() throws {
+        let result = tests.testCawgIdentitySignerReserveSize()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Web Service Signer Tests

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -198,6 +198,11 @@ final class BuilderTests: XCTestCase {
         let result = tests.testBmffMerkleHashing()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testBuilderArchiveFromContext() throws {
+        let result = tests.testBuilderArchiveFromContext()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Reader Tests
@@ -272,6 +277,11 @@ final class ReaderTests: XCTestCase {
 
     func testReaderFromContext() throws {
         let result = tests.testReaderFromContext()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testReaderCrJSON() throws {
+        let result = tests.testReaderCrJSON()
         XCTAssertTrue(result.passed, result.message)
     }
 }

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -850,6 +850,11 @@ final class SignerExtendedTests: XCTestCase {
         let result = tests.testCawgIdentitySignerReserveSize()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testConsumedSignerIsGuarded() throws {
+        let result = tests.testConsumedSignerIsGuarded()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Web Service Signer Tests

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -855,6 +855,11 @@ final class SignerExtendedTests: XCTestCase {
         let result = tests.testConsumedSignerIsGuarded()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testCawgSameInstanceRejected() throws {
+        let result = tests.testCawgSameInstanceRejected()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Web Service Signer Tests

--- a/TestShared/Sources/BuilderTests.swift
+++ b/TestShared/Sources/BuilderTests.swift
@@ -743,6 +743,24 @@ public final class BuilderTests: TestImplementation {
         }
     }
 
+    public func testBuilderArchiveFromContext() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let archiveURL = tempDir.appendingPathComponent("ctxarch_\(UUID().uuidString).c2pa")
+        defer { try? FileManager.default.removeItem(at: archiveURL) }
+        do {
+            let exporter = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            try exporter.writeArchive(to: try Stream(writeTo: archiveURL))
+
+            let context = try C2PAContext()
+            _ = try Builder(context: context, archiveStream: try Stream(readFrom: archiveURL))
+            return .success("Builder Archive From Context", "[PASS] reopened archive via context-configured Builder")
+        } catch let error as C2PAError {
+            return .success("Builder Archive From Context", "[WARN] context archive init callable (error: \(error))")
+        } catch {
+            return .failure("Builder Archive From Context", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         return [
             testBuilderAPI(),
@@ -768,7 +786,8 @@ public final class BuilderTests: TestImplementation {
             testSignDataHashedEmbeddable(),
             testBuilderFromArchiveRoundtrip(),
             testBuilderHashType(),
-            testBmffMerkleHashing()
+            testBmffMerkleHashing(),
+            testBuilderArchiveFromContext()
         ]
     }
 }

--- a/TestShared/Sources/ReaderTests.swift
+++ b/TestShared/Sources/ReaderTests.swift
@@ -565,6 +565,25 @@ public final class ReaderTests: TestImplementation {
         }
     }
 
+    public func testReaderCrJSON() -> TestResult {
+        do {
+            guard let imageData = TestUtilities.loadAdobeTestImage() else {
+                return .failure("Reader crJSON", "Could not load test image")
+            }
+            let stream = try Stream(data: imageData)
+            let reader = try Reader(format: "image/jpeg", stream: stream)
+            let crjson = try reader.crJSON()
+            guard !crjson.isEmpty else {
+                return .failure("Reader crJSON", "crJSON was empty")
+            }
+            return .success("Reader crJSON", "[PASS] crJSON returned \(crjson.count) chars")
+        } catch let error as C2PAError {
+            return .success("Reader crJSON", "[WARN] crJSON callable (error: \(error))")
+        } catch {
+            return .failure("Reader crJSON", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         return [
             testReaderResourceErrorHandling(),
@@ -580,7 +599,8 @@ public final class ReaderTests: TestImplementation {
             testReaderDetailedJSON(),
             testReaderDetailedJSONComparison(),
             testReaderSupportedMimeTypes(),
-            testReaderFromContext()
+            testReaderFromContext(),
+            testReaderCrJSON()
         ]
     }
 }

--- a/TestShared/Sources/SignerExtendedTests.swift
+++ b/TestShared/Sources/SignerExtendedTests.swift
@@ -512,6 +512,63 @@ public final class SignerExtendedTests: TestImplementation {
         }
     }
 
+    public func testCawgIdentitySigner() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sourceURL = tempDir.appendingPathComponent("cawg_src_\(UUID().uuidString).jpg")
+        let destURL = tempDir.appendingPathComponent("cawg_dst_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+        do {
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure("CAWG Identity Signer", "Could not load test image")
+            }
+            try imageData.write(to: sourceURL)
+
+            let claimSigner = try TestUtilities.createTestSigner()
+            let identitySigner = try TestUtilities.createTestSigner()
+            let combined = try Signer.withCawgIdentity(
+                claimSigner,
+                identity: identitySigner,
+                referencedAssertions: ["c2pa.actions"]
+            )
+
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            let sourceStream = try Stream(readFrom: sourceURL)
+            let destStream = try Stream(writeTo: destURL)
+            _ = try builder.sign(
+                format: "image/jpeg",
+                source: sourceStream,
+                destination: destStream,
+                signer: combined
+            )
+
+            if let manifest = try? C2PA.readFile(at: destURL), manifest.contains("cawg.identity") {
+                return .success("CAWG Identity Signer", "[PASS] signed with cawg.identity assertion")
+            }
+            return .success("CAWG Identity Signer", "[PASS] combined signer signed (cawg.identity not asserted in read-back)")
+        } catch let error as C2PAError {
+            return .success("CAWG Identity Signer", "[WARN] CAWG signer callable (error: \(error))")
+        } catch {
+            return .failure("CAWG Identity Signer", "Error: \(error)")
+        }
+    }
+
+    public func testCawgIdentitySignerReserveSize() -> TestResult {
+        do {
+            let claimSigner = try TestUtilities.createTestSigner()
+            let identitySigner = try TestUtilities.createTestSigner()
+            let combined = try Signer.withCawgIdentity(claimSigner, identity: identitySigner)
+            _ = try combined.reserveSize()
+            return .success("CAWG Reserve Size", "[PASS] combined signer reserveSize succeeded")
+        } catch let error as C2PAError {
+            return .success("CAWG Reserve Size", "[WARN] combined signer callable (error: \(error))")
+        } catch {
+            return .failure("CAWG Reserve Size", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         var results: [TestResult] = []
 
@@ -527,6 +584,8 @@ public final class SignerExtendedTests: TestImplementation {
         results.append(testSignerFromSignerInfoWithTSA())
         results.append(testSignerCallbackInvocation())
         results.append(testSignerCallbackErrorPropagation())
+        results.append(testCawgIdentitySigner())
+        results.append(testCawgIdentitySignerReserveSize())
 
         return results
     }

--- a/TestShared/Sources/SignerExtendedTests.swift
+++ b/TestShared/Sources/SignerExtendedTests.swift
@@ -12,6 +12,13 @@ import C2PA
 import Foundation
 import Security
 
+/// Test-only escape hatch: aliases signers outside the compiler's region analysis so the
+/// runtime consumption guards stay exercisable once withCawgIdentity's parameters are `sending`.
+private enum SmuggledSigner {
+    nonisolated(unsafe) static var claim: Signer?
+    nonisolated(unsafe) static var identity: Signer?
+}
+
 // Extended Signer tests - covering reserveSize, exportPublicKeyPEM, loadSettings, etc.
 public final class SignerExtendedTests: TestImplementation {
 
@@ -570,31 +577,79 @@ public final class SignerExtendedTests: TestImplementation {
     }
 
     public func testConsumedSignerIsGuarded() -> TestResult {
-        let claimSigner: Signer
-        let identitySigner: Signer
         do {
-            claimSigner = try TestUtilities.createTestSigner()
-            identitySigner = try TestUtilities.createTestSigner()
+            let claimSigner = try TestUtilities.createTestSigner()
+            let identitySigner = try TestUtilities.createTestSigner()
+            SmuggledSigner.claim = claimSigner
+            SmuggledSigner.identity = identitySigner
             _ = try Signer.withCawgIdentity(claimSigner, identity: identitySigner)
         } catch let error as C2PAError {
+            SmuggledSigner.claim = nil
+            SmuggledSigner.identity = nil
             return .success("Consumed Signer Guarded", "[WARN] setup unavailable (error: \(error))")
         } catch {
+            SmuggledSigner.claim = nil
+            SmuggledSigner.identity = nil
             return .failure("Consumed Signer Guarded", "Setup error: \(error)")
         }
+        defer {
+            SmuggledSigner.claim = nil
+            SmuggledSigner.identity = nil
+        }
 
-        // Both inputs are now consumed; reusing either must throw rather than
-        // dereference a pointer the combined signer owns.
+        // Both inputs are now consumed; reusing either through an alias must throw rather
+        // than dereference a pointer the combined signer owns.
         do {
-            _ = try claimSigner.reserveSize()
+            _ = try SmuggledSigner.claim!.reserveSize()
             return .failure("Consumed Signer Guarded", "reserveSize on a consumed signer should have thrown")
-        } catch is C2PAError {}
+        } catch is C2PAError {
+        } catch {
+            return .failure("Consumed Signer Guarded", "unexpected error type: \(error)")
+        }
 
         do {
-            _ = try Signer.withCawgIdentity(claimSigner, identity: identitySigner)
+            _ = try Signer.withCawgIdentity(SmuggledSigner.claim!, identity: SmuggledSigner.identity!)
             return .failure("Consumed Signer Guarded", "re-combining consumed signers should have thrown")
-        } catch is C2PAError {}
+        } catch is C2PAError {
+        } catch {
+            return .failure("Consumed Signer Guarded", "unexpected error type: \(error)")
+        }
 
         return .success("Consumed Signer Guarded", "[PASS] consumed signers reject reuse")
+    }
+
+    public func testCawgSameInstanceRejected() -> TestResult {
+        let signer: Signer
+        do {
+            signer = try TestUtilities.createTestSigner()
+        } catch {
+            return .failure("CAWG Same Instance Rejected", "Setup error: \(error)")
+        }
+        SmuggledSigner.claim = signer
+        defer { SmuggledSigner.claim = nil }
+
+        do {
+            _ = try Signer.withCawgIdentity(signer, identity: SmuggledSigner.claim!)
+            return .failure(
+                "CAWG Same Instance Rejected", "combining a signer with itself should have thrown")
+        } catch let error as C2PAError {
+            guard "\(error)".contains("distinct") else {
+                return .failure("CAWG Same Instance Rejected", "unexpected error: \(error)")
+            }
+        } catch {
+            return .failure("CAWG Same Instance Rejected", "unexpected error: \(error)")
+        }
+
+        do {
+            _ = try SmuggledSigner.claim!.reserveSize()
+        } catch {
+            return .failure(
+                "CAWG Same Instance Rejected",
+                "signer should remain usable after a rejected combine: \(error)")
+        }
+        return .success(
+            "CAWG Same Instance Rejected",
+            "[PASS] same-instance combine rejected, signer still usable")
     }
 
     public func runAllTests() async -> [TestResult] {
@@ -615,6 +670,7 @@ public final class SignerExtendedTests: TestImplementation {
         results.append(testCawgIdentitySigner())
         results.append(testCawgIdentitySignerReserveSize())
         results.append(testConsumedSignerIsGuarded())
+        results.append(testCawgSameInstanceRejected())
 
         return results
     }

--- a/TestShared/Sources/SignerExtendedTests.swift
+++ b/TestShared/Sources/SignerExtendedTests.swift
@@ -569,6 +569,34 @@ public final class SignerExtendedTests: TestImplementation {
         }
     }
 
+    public func testConsumedSignerIsGuarded() -> TestResult {
+        let claimSigner: Signer
+        let identitySigner: Signer
+        do {
+            claimSigner = try TestUtilities.createTestSigner()
+            identitySigner = try TestUtilities.createTestSigner()
+            _ = try Signer.withCawgIdentity(claimSigner, identity: identitySigner)
+        } catch let error as C2PAError {
+            return .success("Consumed Signer Guarded", "[WARN] setup unavailable (error: \(error))")
+        } catch {
+            return .failure("Consumed Signer Guarded", "Setup error: \(error)")
+        }
+
+        // Both inputs are now consumed; reusing either must throw rather than
+        // dereference a pointer the combined signer owns.
+        do {
+            _ = try claimSigner.reserveSize()
+            return .failure("Consumed Signer Guarded", "reserveSize on a consumed signer should have thrown")
+        } catch is C2PAError {}
+
+        do {
+            _ = try Signer.withCawgIdentity(claimSigner, identity: identitySigner)
+            return .failure("Consumed Signer Guarded", "re-combining consumed signers should have thrown")
+        } catch is C2PAError {}
+
+        return .success("Consumed Signer Guarded", "[PASS] consumed signers reject reuse")
+    }
+
     public func runAllTests() async -> [TestResult] {
         var results: [TestResult] = []
 
@@ -586,6 +614,7 @@ public final class SignerExtendedTests: TestImplementation {
         results.append(testSignerCallbackErrorPropagation())
         results.append(testCawgIdentitySigner())
         results.append(testCawgIdentitySignerReserveSize())
+        results.append(testConsumedSignerIsGuarded())
 
         return results
     }


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
Adds Signer.withCawgIdentity(_:identity:referencedAssertions:roles:), wrapping c2pa_identity_signer_create to combine a claim signer with an X.509 identity signer into a single signer that emits a cawg.identity assertion.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment